### PR TITLE
Fix bokeh version for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pydub
-bokeh
+bokeh==2.4.3
 ipython
 audio-plot-lib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydub
+pydub==0.24.1
 bokeh==2.4.3
 ipython
 audio-plot-lib

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md") as f:
 
 setup(
     name="audio-plot-lib",
-    version="0.1.0",
+    version="0.1.1",
     description="Plot tools based on audio",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/hassaku/audio-plot-lib",
     packages=["audio_plot_lib"],
     include_package_data=True,
-    install_requires=["pydub", "numpy", "gTTS", "bokeh", "ipython"],
+    install_requires=["pydub==0.24.1", "numpy", "gTTS==2.2.1", "bokeh==2.4.3", "ipython"],
     tests_require=[],
     license="MIT",
     keywords="audio plot visually-impaired",


### PR DESCRIPTION
The change to version 3 of bokeh has caused errors #1 in the compatibility portion of the interface. Workaround for now is to fix the version back to the way it was before.

